### PR TITLE
updating wav module, buggy block stream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,7 @@ go 1.17
 
 require (
 	github.com/JoshVarga/blast v0.0.0-20210808061142-eadad17358e8
+	github.com/OpenDiablo2/OpenDiablo2 v0.0.0-20210514222603-a688d660a0f7 // indirect
+	github.com/OpenDiablo2/bitstream v0.0.0-20210818234514-9fca7e40e2b3 // indirect
 	github.com/OpenDiablo2/wav v0.0.0-20210822025314-429cc1291a8e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,11 @@ github.com/JoshVarga/blast v0.0.0-20210808061142-eadad17358e8 h1:9bbQDlx6h7MyNk3
 github.com/JoshVarga/blast v0.0.0-20210808061142-eadad17358e8/go.mod h1:rwSKMTLI/8tbw6YDRqtd3Hc0OI3eP/tSTVKshyd8dO8=
 github.com/OpenDiablo2/OpenDiablo2 v0.0.0-20210514222603-a688d660a0f7 h1:TGxU+HHMHIl5aOZk/Yd3uEP+ALbxvysnuhbMkg1f6xY=
 github.com/OpenDiablo2/OpenDiablo2 v0.0.0-20210514222603-a688d660a0f7/go.mod h1:IzC2iZNeFCs35eOl/wdvzqSGkHs30d94zomUoaA9QT0=
+github.com/OpenDiablo2/bitstream v0.0.0-20210818234514-9fca7e40e2b3/go.mod h1:Wrs2YpoAmqLq/uBAKxZnW145BgzsVsLwxafjI3hkMhE=
 github.com/OpenDiablo2/wav v0.0.0-20210822025314-429cc1291a8e h1:DHJ5UkDi6RbikGTCxQNM/bGajCBdexnjrYS/B1607fs=
 github.com/OpenDiablo2/wav v0.0.0-20210822025314-429cc1291a8e/go.mod h1:0wUOukC+ZCJWRgm9TabI+ufNcMjzGNKmwkWFeteM/Os=
+github.com/OpenDiablo2/wav v0.0.0-20210828190011-f697e913d00c h1:wRpIafCjGX52ECHPz/TfW9rnmblsR3D7/gyHXLeNGVU=
+github.com/OpenDiablo2/wav v0.0.0-20210828190011-f697e913d00c/go.mod h1:/v9+e1UEXO5sQs5VTVlM5oMRnUnYfvf4MlymFGdzebw=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/data_stream.go
+++ b/pkg/data_stream.go
@@ -1,5 +1,9 @@
 package pkg
 
+import (
+	"io"
+)
+
 // DataStream represents a stream for MPQ data.
 type DataStream struct {
 	stream *Stream
@@ -13,7 +17,15 @@ func (m *DataStream) Read(p []byte) (n int, err error) {
 
 // Seek sets the position of the data stream
 func (m *DataStream) Seek(offset int64, whence int) (int64, error) {
-	m.stream.Position = uint32(offset + int64(whence))
+	switch whence {
+	case io.SeekStart:
+		m.stream.Position = uint32(offset)
+	case io.SeekEnd:
+		m.stream.Position = uint32(m.stream.Size) - uint32(offset)
+	case io.SeekCurrent:
+		m.stream.Position += uint32(offset)
+	}
+
 	return int64(m.stream.Position), nil
 }
 


### PR DESCRIPTION
currently, block stream ReadSeeker is bugged. 

## Using bitstream with the mpq block stream has strange results, because we've never properly used the `whence` argument for read seeker inside of mpq block stream impl.